### PR TITLE
Add generate x-langserver-token

### DIFF
--- a/docs/review.md
+++ b/docs/review.md
@@ -15,7 +15,7 @@ class Review:
 
 ```python
 from rayyan import Rayyan
-from rayyan.review import Review
+from rayyan.reviews import Review
 
 rayyan = Rayyan("cred.json")
 review_instance = Review(rayyan)

--- a/nb.ipynb
+++ b/nb.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "from rayyan import StatelessRayyan as client\n",
-    "from rayyan.review import Review\n",
+    "from rayyan.reviews import Review\n",
     "from rayyan.mylib import MyLib\n",
     "\n",
     "access_token = \"\"\n",

--- a/rayyan-api.ipynb
+++ b/rayyan-api.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rayyan.review import Review\n",
+    "from rayyan.reviews import Review\n",
     "rayyan_review = Review(rayyan)\n",
     "reviews = rayyan_review.get_all()\n",
     "pprint(reviews)\n",

--- a/rayyan/reviews/__init__.py
+++ b/rayyan/reviews/__init__.py
@@ -9,6 +9,7 @@ from .articles import ReviewArticles
 from .customizations import ReviewCustomizations
 from .metadata import ReviewMetadata
 from .fulltext import ReviewFulltext
+from .embeddings import ReviewEmbeddings
 from rayyan.duplicates import Duplicates
 
 class Review(
@@ -23,6 +24,7 @@ class Review(
     ReviewCustomizations,
     ReviewMetadata,
     ReviewFulltext,
+    ReviewEmbeddings,
     Duplicates,
 ):
     """Facade combining all review-related mixins into a single client class.

--- a/rayyan/reviews/embeddings.py
+++ b/rayyan/reviews/embeddings.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict
+from rayyan.paths import REVIEWS_ROUTE
+
+
+class ReviewEmbeddings:
+    def get_embedding_token(self, review_id: int) -> Dict[str, Any]:
+        """
+        Retrieve the embedding token for a review.
+        """
+        return self._request("GET", f"{REVIEWS_ROUTE}/{review_id}/embeddings")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = rayyan_sdk
-version = 1.0rc15
+version = 1.0rc16
 description = A Python SDK for Rayyan APIs
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This PR introduces a new helper method for retrieving embedding tokens for a given review.

**What’s added**
  `ReviewEmbeddings.get_embedding_token(review_id: int)`
  Wraps the existing `GET /reviews/{id}/embeddings` endpoint.
  Returns structured token data as a `Dict[str, Any]`.
  Provides a simple, dedicated API surface for embedding-related operations.

**Why**
  Centralizes the logic for requesting embedding tokens.
  Improves readability and consistency across the client API.
  Prepares the codebase for upcoming features involving embeddings and lang-server integration.

**How**
  Uses the existing _request method to perform the HTTP call.
  Constructs the route using `REVIEWS_ROUTE` for safety and consistency.